### PR TITLE
fix unregister loop

### DIFF
--- a/samples/vanDerPol/main.py
+++ b/samples/vanDerPol/main.py
@@ -315,12 +315,13 @@ def main(config_setup: bool = False):
             elif event.type == "EpisodeFinish":
                 print("Episode Finishing...")
             elif event.type == "Unregister":
-                print("Simulator Session unregistered by platform because '{}', Registering again!".format(event.unregister.details))
+                print("Simulator Session unregistered by platform because '{}'.".format(event.unregister.details))
                 client.session.delete(
                     workspace_name=config_client.workspace,
                     session_id=registered_session.session_id,
                 )
-                print("Unregistered simulator.")
+                print("Unregistered simulator. Exiting.")
+                return
             else:
                 pass
     except KeyboardInterrupt:


### PR DESCRIPTION
When receiving an Unregister event, the simulator was deleting its session but continuing to run. This placed it in a loop where it received the unregister event over and over again.

It looks like the intent was to unregister and exit, so I'm changing the logic to do that.