### PR TITLE
install visual C++ runtime in FMU base image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@
 
 # Don't check this file in
 fm_RSM_FMU_Pipeline.fmu
+Aircraft_*.fmu

--- a/Dockerfile-windows_FMU_BASE
+++ b/Dockerfile-windows_FMU_BASE
@@ -4,6 +4,13 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2019 AS fmu_base
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# Install Microsoft Visual C++ runtime as described at https://github.com/microsoft/dotnet-framework-docker/issues/15#issuecomment-1068934155
+# Some FMU DLLs have dependencies on this runtime
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest "https://aka.ms/vs/17/release/vc_redist.x64.exe" -OutFile "vc_redist.x64.exe"; \
+	Start-Process -filepath C:\vc_redist.x64.exe -ArgumentList "/install", "/passive", "/norestart" -Passthru | Wait-Process; \
+	Remove-Item -Force vc_redist.x64.exe;
+
 ENV PYTHON_VERSION 3.7.8
 ENV PYTHON_RELEASE 3.7.8
 

--- a/samples/test-fmu.py
+++ b/samples/test-fmu.py
@@ -68,6 +68,10 @@ def main(mode: str, fmu_path: str):
     if has_error:
         return
 
+    # Run a simple Bonsai CLI command. This will prompt the user if they need to log in for the CLI.
+    print_highlighted("Log in to Bonsai CLI (if needed)")
+    run_command("bonsai -s")
+
     # Determine the FMU connector root directory by its relative path from this script file.
     root_dir = pathlib.Path(__file__).resolve().parent.parent
 
@@ -106,10 +110,13 @@ def main(mode: str, fmu_path: str):
         run_command(f"docker build -t fmu_runtime:latest -f {root_dir}\\Dockerfile-windows_FMU_RUNTIME {root_dir}")
         print()
 
-        if mode == "local-container":
+        if mode == "local-container" or mode == "local-container-interactive":
 
             print_highlighted("Launching local container")
-            run_command(f"start docker run -it --rm -e SIM_ACCESS_KEY=%SIM_ACCESS_KEY% -e SIM_WORKSPACE=%SIM_WORKSPACE% fmu_runtime:latest")
+            command_line = f"start docker run -it --rm -e SIM_ACCESS_KEY=%SIM_ACCESS_KEY% -e SIM_WORKSPACE=%SIM_WORKSPACE% fmu_runtime:latest"
+            if mode == "local-container-interactive":
+                command_line += " powershell" # tell docker to launch the container with a PowerShell prompt instead of running the CMD
+            run_command(command_line)
 
         elif mode == "managed":
 
@@ -168,7 +175,7 @@ managed: Build the connector containers and add them as a managed simulator in y
 
     parser.add_argument(
         "--mode",
-        choices=["local", "local-container", "managed"],
+        choices=["local", "local-container", "local-container-interactive", "managed"],
         required=True,
         help=mode_help,
     )


### PR DESCRIPTION
Also:
* Prompt user to log in (if needed) at the start of test-fmu.
* Add local-container-interactive to test-fmu. Launches the container to the command console so you can poke around and try running your own commands.
* Add Aircraft_*.fmu to .gitignore so we don't accidentally check it in.