### PR TITLE
support .fmu file extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,9 @@
 /generic/interface.json
 
 
-# Don't check in the Sim.zip file copied into the root when building containers
+# Don't check in the Sim.zip/fmu file copied into the root when building containers
 /Sim.zip
+/Sim.fmu
 
 # Don't check this file in
 fm_RSM_FMU_Pipeline.fmu

--- a/Dockerfile-windows_FMU_RUNTIME
+++ b/Dockerfile-windows_FMU_RUNTIME
@@ -1,8 +1,17 @@
 FROM fmu_base
 
-COPY ./sim.zip /src/generic/generic.fmu
+COPY ./sim.* /zip/
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# If the model file is a zip file, unzip it
+RUN if(Test-Path -Path "/zip/sim.zip"){ Expand-Archive -LiteralPath "/zip/sim.zip" -DestinationPath "/zip" }
+
+# Copy the FMU model file into the generic folder
+RUN CP /zip/*.fmu /src/generic/generic.fmu
+
+# Copy the transform.py file (if it exists) over the default version in FMU_Connector
+RUN CP /zip/transform*.py /src/FMU_Connector/
+
 # Run main task
-CMD "python .\generic\main.py"
+CMD "python .\\generic\\main.py"

--- a/Dockerfile-windows_FMU_RUNTIME
+++ b/Dockerfile-windows_FMU_RUNTIME
@@ -1,14 +1,8 @@
 FROM fmu_base
 
-COPY ./sim.zip /zip/sim.zip
+COPY ./sim.zip /src/generic/generic.fmu
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
-RUN Expand-Archive -LiteralPath "/zip/sim.zip" -DestinationPath "/zip"
-
-RUN CP /zip/*.fmu /src/generic/generic.fmu
-# Copy the transform.py file (if it exists) over the default version in FMU_Connector
-RUN CP /zip/transform*.py /src/FMU_Connector/
 
 # Run main task
 CMD "python .\generic\main.py"

--- a/samples/test-fmu.py
+++ b/samples/test-fmu.py
@@ -87,7 +87,7 @@ def main(mode: str, fmu_path: str, transform_path: str):
 
     if mode == "local":
 
-        print_highlighted("Copying new sample files")
+        print_highlighted("Copying sample file")
         generic_fmu_path = f"{root_dir}\\generic\\generic.fmu"
         shutil.copyfile(fmu_path, generic_fmu_path)
         print(f"  copied {fmu_path} -> {generic_fmu_path}")
@@ -102,14 +102,15 @@ def main(mode: str, fmu_path: str, transform_path: str):
         run_command(f"docker build -t fmu_base:latest -f {root_dir}\\Dockerfile-windows_FMU_BASE {root_dir}")
         print()
 
-        print(f"* Zipping {fmu_path}")
+        print(f"* Copying sample file")
         zip_path = f"{root_dir}\\Sim.zip"
-        with ZipFile(zip_path, 'w') as zipfile:
-            zipfile.write(fmu_path, arcname=pathlib.Path(fmu_path).name)
-            if transform_path:
-                print(f"* Zipping {transform_path}")
-                zipfile.write(transform_path, arcname="transform.py")
-        print(f"  zipped {fmu_path} -> {zip_path}")
+        shutil.copyfile(fmu_path, zip_path)
+        print(f"  copied {fmu_path} -> {zip_path}")
+        if transform_path:
+            print("TODO: How to handle transform file now that we are no longer keeping the FMU inside a zip file.")
+            #print(f"* Zipping {transform_path}")
+            #zipfile.write(transform_path, arcname="transform.py")
+            pass
         print()
 
         print_highlighted("Building runtime image")

--- a/samples/test-fmu.py
+++ b/samples/test-fmu.py
@@ -80,6 +80,7 @@ def main(mode: str, fmu_path: str, transform_path: str):
 
     print_highlighted("Cleaning up previous temporary sample files")
     delete_if_exists(f"{root_dir}\\sim.zip")
+    delete_if_exists(f"{root_dir}\\sim.fmu")
     delete_if_exists(f"{root_dir}\\generic\\generic.fmu")
     delete_if_exists(f"{root_dir}\\generic\\generic_conf.yaml")
     delete_if_exists(f"{root_dir}\\generic\\generic_unzipped", is_directory = True)
@@ -102,10 +103,10 @@ def main(mode: str, fmu_path: str, transform_path: str):
         run_command(f"docker build -t fmu_base:latest -f {root_dir}\\Dockerfile-windows_FMU_BASE {root_dir}")
         print()
 
-        print(f"* Copying sample file")
-        zip_path = f"{root_dir}\\Sim.zip"
-        shutil.copyfile(fmu_path, zip_path)
-        print(f"  copied {fmu_path} -> {zip_path}")
+        print(f"Copying sample file")
+        root_path = f"{root_dir}\\sim.fmu"
+        shutil.copyfile(fmu_path, root_path)
+        print(f"  copied {fmu_path} -> {root_path}")
         if transform_path:
             print("TODO: How to handle transform file now that we are no longer keeping the FMU inside a zip file.")
             #print(f"* Zipping {transform_path}")

--- a/samples/vanDerPol.ink
+++ b/samples/vanDerPol.ink
@@ -62,6 +62,7 @@ type SimAction {
 type SimConfig {
     # Oscillation parameter
     mu: number<0.5 .. 4>,
+    FMU_state_includes_action: number,
 }
 
 # Define a concept graph with a single concept
@@ -96,7 +97,8 @@ graph (input: ObservableState) {
                 # from one episode to the next during this lesson.
                 scenario {
                     # Oscillation parameter
-                    mu: number<0.5 .. 4>
+                    mu: number<0.5 .. 4>,
+                    FMU_state_includes_action: 1,
                 }
             }
         }


### PR DESCRIPTION
With client/server changes in Bonsai, we no longer need to put .fmu files inside zip files.
* Dockerfile support for either nested .zip or .fmu file
* Test script now uses .fmu files directly (we will no longer test using .zip)
* Also, fix vanDerPol Inkling that wasn't working because it needs the FMU_state_includes_action feature
